### PR TITLE
Added a tooltip displaying names of skills on hovering on skill icons

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,6 +14,8 @@ import { IntroHeading } from "../src/data/sections";
 import Footer from "../src/components/Footer";
 import BlogSection from "../src/sections/Blog";
 import Head from "next/head";
+import { TooltipProvider } from "../src/context/useTooltipContext";
+import Tooltip from "../src/components/Tooltip";
 
 export default function Home({
   posts,
@@ -48,19 +50,22 @@ export default function Home({
           setVisibleSection,
         }}
       >
-        <Navbar refs={sectionRefs} ref={headerRef} />
-        <Sidebar refs={sectionRefs} />
-        <Introduction
-          ref={introHeadingRef}
-          aboutRef={aboutRef}
-          headerRef={headerRef}
-        />
-        <About ref={aboutRef} />
-        <Skills ref={skillsRef} />
-        <Projects ref={projectsRef} />
-        <BlogSection ref={blogRef} posts={posts} />
-        <Contact ref={contactRef} />
-        <Footer />
+        <TooltipProvider>
+          <Tooltip />
+          <Navbar refs={sectionRefs} ref={headerRef} />
+          <Sidebar refs={sectionRefs} />
+          <Introduction
+            ref={introHeadingRef}
+            aboutRef={aboutRef}
+            headerRef={headerRef}
+          />
+          <About ref={aboutRef} />
+          <Skills ref={skillsRef} />
+          <Projects ref={projectsRef} />
+          <BlogSection ref={blogRef} posts={posts} />
+          <Contact ref={contactRef} />
+          <Footer />
+        </TooltipProvider>
       </GlobalContext.Provider>
     </>
   );

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,0 +1,34 @@
+import { MutableRefObject, useEffect, useRef } from "react";
+import { useTooltipContext } from "../../context/useTooltipContext";
+import cn from "classnames";
+import styles from "./tooltip.module.scss";
+
+const Tooltip = () => {
+  const {
+    state: {
+      tooltip: { location, text },
+    },
+  } = useTooltipContext();
+
+  useEffect(() => {
+    if (text) {
+      tooltipRef.current.style.top = `${location.bottom}px`;
+      tooltipRef.current.style.left = `${location.center}px`;
+    }
+  }, [location, text]);
+
+  const tooltipRef = useRef() as MutableRefObject<HTMLElement>;
+
+  return (
+    <span
+      ref={tooltipRef}
+      className={
+        text ? cn(styles["tooltip"], styles["tooltip-show"]) : styles["tooltip"]
+      }
+    >
+      {text}
+    </span>
+  );
+};
+
+export default Tooltip;

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,13 +1,18 @@
 import { MutableRefObject, useEffect, useRef } from "react";
-import { useTooltipContext } from "../../context/useTooltipContext";
+import {
+  TooltipActionTypes,
+  useTooltipContext,
+} from "../../context/useTooltipContext";
 import cn from "classnames";
 import styles from "./tooltip.module.scss";
+import useWindowDimensions from "../../hooks/useWindowDimensions";
 
 const Tooltip = () => {
   const {
     state: {
       tooltip: { location, text },
     },
+    dispatch,
   } = useTooltipContext();
 
   useEffect(() => {
@@ -16,6 +21,28 @@ const Tooltip = () => {
       tooltipRef.current.style.left = `${location.center}px`;
     }
   }, [location, text]);
+
+  const { isMobileView } = useWindowDimensions();
+
+  // In mobile view, delete the tooltip on scroll from icon
+  // TO-DO: Find a better approach to resolve this issue
+  useEffect(() => {
+    const deleteTooltipOnScroll = () => {
+      dispatch({
+        type: TooltipActionTypes.DELETE_TOOLTIP,
+      });
+    };
+
+    if (isMobileView) {
+      window.addEventListener("scroll", deleteTooltipOnScroll);
+    }
+
+    return () => {
+      if (isMobileView) {
+        window.removeEventListener("scroll", deleteTooltipOnScroll);
+      }
+    };
+  }, [isMobileView, dispatch]);
 
   const tooltipRef = useRef() as MutableRefObject<HTMLElement>;
 

--- a/src/components/Tooltip/tooltip.module.scss
+++ b/src/components/Tooltip/tooltip.module.scss
@@ -1,0 +1,32 @@
+.tooltip {
+  display: none;
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-weight: 700;
+  text-align: center;
+  background-color: #fff;
+  position: fixed;
+  transform: translateX(-50%);
+  z-index: 10;
+  transition: all 0.3s linear;
+  color: #6d61ee;
+  box-shadow: 2px 2px 10px 0px #6d61ee;
+
+  &-show {
+    display: block;
+  }
+
+  &::before {
+    content: "";
+    display: block;
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 5px solid #fff;
+    position: absolute;
+    top: -5px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}

--- a/src/context/useTooltipContext.tsx
+++ b/src/context/useTooltipContext.tsx
@@ -1,0 +1,84 @@
+import { createContext, ReactNode, useContext, useReducer } from "react";
+
+type ChildrenProps = {
+  children: ReactNode;
+};
+
+export type Location = {
+  bottom: number;
+  center: number;
+};
+
+export enum TooltipActionTypes {
+  CREATE_TOOLTIP = "CREATE_TOOLTIP",
+  DELETE_TOOLTIP = "DELETE_TOOLTIP",
+}
+
+export type CreateTooltip = {
+  type: TooltipActionTypes.CREATE_TOOLTIP;
+  text: string;
+  location: Location;
+};
+
+export type DeleteTooltip = {
+  type: TooltipActionTypes.DELETE_TOOLTIP;
+};
+
+type Action = CreateTooltip | DeleteTooltip;
+
+type State = {
+  tooltip: {
+    text: string;
+    location: { bottom: number; center: number };
+  };
+};
+
+type Dispatch = (action: Action) => void;
+
+const initialState: State = {
+  tooltip: {
+    text: "",
+    location: { bottom: -1, center: -1 },
+  },
+};
+
+const TooltipReducer = (state = initialState, action: Action): State => {
+  switch (action.type) {
+    case TooltipActionTypes.CREATE_TOOLTIP:
+      return {
+        ...state,
+        tooltip: { text: action.text, location: action.location },
+      };
+    case TooltipActionTypes.DELETE_TOOLTIP:
+      return {
+        ...state,
+        tooltip: { ...initialState.tooltip },
+      };
+    default:
+      throw new Error("No action of this type exists!");
+  }
+};
+
+export const TooltipContext = createContext<
+  { state: State; dispatch: Dispatch } | undefined
+>(undefined);
+
+export const TooltipProvider = ({ children }: ChildrenProps) => {
+  const [state, dispatch] = useReducer(TooltipReducer, initialState);
+
+  const value = { state, dispatch };
+
+  return (
+    <TooltipContext.Provider value={value}>{children}</TooltipContext.Provider>
+  );
+};
+
+export const useTooltipContext = () => {
+  const context = useContext(TooltipContext);
+
+  if (context === undefined) {
+    throw new Error("No value provided for context!");
+  }
+
+  return context;
+};

--- a/src/data/skills.tsx
+++ b/src/data/skills.tsx
@@ -4,24 +4,35 @@ import {
   SiTypescript,
   SiFirebase,
   SiGit,
-  SiMysql,
-  SiJava
+  SiNextDotJs,
+  SiAngular,
 } from "react-icons/si";
 import { FaSass } from "react-icons/fa";
+import { MutableRefObject, useRef } from "react";
 export const skills = [
+  {
+    title: "TypeScript",
+    icon: <SiTypescript />,
+    color: "#fff",
+  },
   {
     title: "React",
     icon: <SiReact />,
     color: "#fff",
   },
   {
-    title: "Redux",
-    icon: <SiRedux />,
+    title: "Next.js",
+    icon: <SiNextDotJs />,
     color: "#fff",
   },
   {
-    title: "TypeScript",
-    icon: <SiTypescript />,
+    title: "Angular",
+    icon: <SiAngular />,
+    color: "#fff",
+  },
+  {
+    title: "Redux",
+    icon: <SiRedux />,
     color: "#fff",
   },
   {
@@ -32,16 +43,6 @@ export const skills = [
   {
     title: "Firebase",
     icon: <SiFirebase />,
-    color: "#fff",
-  },
-  {
-    title: "Java",
-    icon: <SiJava />,
-    color: "#fff",
-  },
-  {
-    title: "SQL",
-    icon: <SiMysql />,
     color: "#fff",
   },
   {

--- a/src/sections/Skills/index.tsx
+++ b/src/sections/Skills/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, MouseEvent, MutableRefObject, useRef } from "react";
 import cn from "classnames";
 import Layout from "../../components/Layout";
 import useWindowDimensions from "../../hooks/useWindowDimensions";
@@ -7,10 +7,35 @@ import layoutStyles from "../../components/Layout/layout.module.scss";
 import sectionStyles from "../section.module.scss";
 import { skills } from "../../data/skills";
 import { IconContext } from "react-icons/lib";
-
+import {
+  TooltipActionTypes,
+  useTooltipContext,
+} from "../../context/useTooltipContext";
 
 const Skills = forwardRef<HTMLElement>((props, ref) => {
   const { isMobileView } = useWindowDimensions();
+
+  const { dispatch } = useTooltipContext();
+
+  const displayTooltip = (e: MouseEvent<HTMLElement>, title: string) => {
+    const pos = e.currentTarget.getBoundingClientRect();
+    const center = (pos.left + pos.right) / 2;
+    const bottom = pos.bottom + 15;
+
+    if (title) {
+      dispatch({
+        type: TooltipActionTypes.CREATE_TOOLTIP,
+        text: title,
+        location: { center, bottom },
+      });
+    }
+  };
+
+  const closeTooltip = () => {
+    dispatch({
+      type: TooltipActionTypes.DELETE_TOOLTIP,
+    });
+  };
 
   return (
     <IconContext.Provider
@@ -22,31 +47,15 @@ const Skills = forwardRef<HTMLElement>((props, ref) => {
     >
       <Layout>
         <section ref={ref} className={layoutStyles.section}>
-          <h1 className={cn("section-title", styles["skills-title"])}>Skills</h1>
+          <h1 className={cn("section-title", styles["skills-title"])}>
+            Skills
+          </h1>
           <span
             className={cn(sectionStyles["section-text"], styles["skills-text"])}
           >
             Being a developer is to be always learning and evolving constantly.
             Currently while building things for the web, I’m working on and
             learning these technologies and trying to grasp a few others like{" "}
-            <a
-              href="https://nextjs.org/"
-              target="_blank"
-              rel="noreferrer"
-              className={sectionStyles["section-text-highlight"]}
-            >
-              Next.js
-            </a>
-            ,{" "}
-            <a
-              href="https://angular.io/"
-              target="_blank"
-              rel="noreferrer"
-              className={sectionStyles["section-text-highlight"]}
-            >
-              Angular
-            </a>
-            ,{" "}
             <a
               href="https://nodejs.org/en/"
               target="_blank"
@@ -69,8 +78,11 @@ const Skills = forwardRef<HTMLElement>((props, ref) => {
           <ul className={styles["skills-list"]}>
             {skills.map(({ title, icon }, index) => (
               <li key={index} className={styles["skills-list-item"]}>
-                {/* <h4>{title}</h4> */}
-                <span className={styles["skills-icon"]}>
+                <span
+                  className={styles["skills-icon"]}
+                  onMouseEnter={(e) => displayTooltip(e, title)}
+                  onMouseLeave={() => closeTooltip()}
+                >
                   {icon}
                 </span>
               </li>

--- a/src/sections/Skills/skills.module.scss
+++ b/src/sections/Skills/skills.module.scss
@@ -6,7 +6,7 @@
   &-list {
     display: flex;
     flex-wrap: wrap;
-    gap: 5vh 5vw;
+    gap: 6vh 5vw;
     margin-top: 4vh;
     width: 90%;
   }
@@ -22,12 +22,12 @@
       padding: 5px;
       &:hover {
         color: $primary-color-light;
-        transform: scale(1.2) rotate(-6deg);
+        transform: scale(1.1);
         transition: 0.3s ease;
       }
     }
     &:hover {
-      transform: scale(1.2) rotate(-6deg);
+      transform: scale(1.1);
       transition: 0.3s ease;
     }
   }


### PR DESCRIPTION
- Added an extra scroll event listener for removing the tooltip on scroll for smaller viewports (tabs, mobile etc.)
- Updated skills

UI Refrence:

<img width="1280" alt="Screenshot 2022-01-13 at 12 23 05 PM" src="https://user-images.githubusercontent.com/52678249/149559109-d8f2b667-3925-456f-8204-1b283f1d22d8.png">



